### PR TITLE
Fix typo for dns_zone_name in variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,8 +51,9 @@ variable "subnet_ids" {
   type        = list(string)
 }
 variable "dns_zone_name" {
-  default = "(Optional) The name of Route53 Private DNS zone. If not provided - DNS record will not be created"
-  type    = string
+  description = "(Optional) The name of Route53 Private DNS zone. If not provided - DNS record will not be created"
+  default     = ""
+  type        = string
 }
 variable "customer_default_sg_id" {
   description = "(Optional) List of preexisting security groups to be attached to the instance. The required security groups are created automatically, this is just for mandatory default ones"


### PR DESCRIPTION
*Issue #, if available:*
Typo in variables.tf that assigns the default value of `dns_zone_name` to the description

*Description of changes:*
Fix typo & assign default of empty string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
